### PR TITLE
Added Floating Action Button to scaffold layout

### DIFF
--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
@@ -100,10 +100,10 @@ fun CollapsingToolbarScaffold(
 			minWidth = 0,
 			minHeight = 0,
 			maxHeight =
-			if(scrollStrategy == ScrollStrategy.ExitUntilCollapsed)
-				max(0, constraints.maxHeight - toolbarState.minHeight)
-			else
-				constraints.maxHeight
+				if(scrollStrategy == ScrollStrategy.ExitUntilCollapsed)
+					max(0, constraints.maxHeight - toolbarState.minHeight)
+				else
+					constraints.maxHeight
 		)
 
 		val toolbarPlaceables = subcompose(CollapsingToolbarScaffoldContent.Toolbar) {

--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
@@ -24,7 +24,6 @@ package me.onebone.toolbar
 
 import android.os.Bundle
 import androidx.compose.foundation.gestures.ScrollableDefaults
-import androidx.compose.material.FabPosition
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
@@ -35,8 +34,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.SubcomposeLayout
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
 import kotlin.math.max
 
 @Stable
@@ -80,8 +77,6 @@ fun CollapsingToolbarScaffold(
 	scrollStrategy: ScrollStrategy,
 	toolbarModifier: Modifier = Modifier,
 	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
-	floatingActionButton: @Composable () -> Unit = {},
-	floatingActionButtonPosition: FabPosition = FabPosition.End,
 	body: @Composable () -> Unit
 ) {
 	val flingBehavior = ScrollableDefaults.flingBehavior()
@@ -105,10 +100,10 @@ fun CollapsingToolbarScaffold(
 			minWidth = 0,
 			minHeight = 0,
 			maxHeight =
-				if(scrollStrategy == ScrollStrategy.ExitUntilCollapsed)
-					max(0, constraints.maxHeight - toolbarState.minHeight)
-				else
-					constraints.maxHeight
+			if(scrollStrategy == ScrollStrategy.ExitUntilCollapsed)
+				max(0, constraints.maxHeight - toolbarState.minHeight)
+			else
+				constraints.maxHeight
 		)
 
 		val toolbarPlaceables = subcompose(CollapsingToolbarScaffoldContent.Toolbar) {
@@ -131,48 +126,6 @@ fun CollapsingToolbarScaffold(
 
 		val toolbarHeight = toolbarPlaceables.maxOfOrNull { it.height } ?: 0
 
-		val fabConstraints = constraints.copy(
-			minWidth = 0,
-			minHeight = 0
-		)
-
-		val fabPlaceables = subcompose(
-			CollapsingToolbarScaffoldContent.Fab,
-			floatingActionButton
-		).mapNotNull { measurable ->
-			measurable.measure(fabConstraints).takeIf { it.height != 0 && it.width != 0 }
-		}
-
-		val fabPlacement = if (fabPlaceables.isNotEmpty()) {
-			val fabWidth = fabPlaceables.maxOfOrNull { it.width } ?: 0
-			val fabHeight = fabPlaceables.maxOfOrNull { it.height } ?: 0
-			// FAB distance from the left of the layout, taking into account LTR / RTL
-			val fabLeftOffset = if (floatingActionButtonPosition == FabPosition.End) {
-				if (layoutDirection == LayoutDirection.Ltr) {
-					constraints.maxWidth - 16.dp.roundToPx() - fabWidth
-				} else {
-					16.dp.roundToPx()
-				}
-			} else {
-				(constraints.maxWidth - fabWidth) / 2
-			}
-
-			FabPlacement(
-				isDocked = false,
-				left = fabLeftOffset,
-				width = fabWidth,
-				height = fabHeight
-			)
-		} else {
-			null
-		}
-
-
-		val fabOffsetFromBottom = fabPlacement?.let {
-			it.height + 16.dp.roundToPx()
-		}
-
-
 		val height = max(
 			toolbarHeight,
 			bodyPlaceables.maxOfOrNull { it.height } ?: 0
@@ -186,16 +139,10 @@ fun CollapsingToolbarScaffold(
 			toolbarPlaceables.forEach {
 				it.place(0, state.offsetY)
 			}
-
-			fabPlacement?.let { placement ->
-				fabPlaceables.forEach {
-					it.place(placement.left, constraints.maxHeight - fabOffsetFromBottom!!)
-				}
-			}
 		}
 	}
 }
 
 private enum class CollapsingToolbarScaffoldContent {
-	Toolbar, Body, Fab
+	Toolbar, Body
 }

--- a/lib/src/main/java/me/onebone/toolbar/FabPlacement.kt
+++ b/lib/src/main/java/me/onebone/toolbar/FabPlacement.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 onebone <me@onebone.me>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package me.onebone.toolbar
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+class FabPlacement(
+	val isDocked: Boolean,
+	val left: Int,
+	val width: Int,
+	val height: Int
+)

--- a/lib/src/main/java/me/onebone/toolbar/FabPlacement.kt
+++ b/lib/src/main/java/me/onebone/toolbar/FabPlacement.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.Immutable
 
 @Immutable
 class FabPlacement(
-	val isDocked: Boolean,
 	val left: Int,
 	val width: Int,
 	val height: Int

--- a/lib/src/main/java/me/onebone/toolbar/FabPosition.kt
+++ b/lib/src/main/java/me/onebone/toolbar/FabPosition.kt
@@ -1,0 +1,19 @@
+package me.onebone.toolbar
+
+
+@Suppress("INLINE_CLASS_DEPRECATED", "EXPERIMENTAL_FEATURE_WARNING")
+inline class FabPosition internal constructor(@Suppress("unused") private val value: Int) {
+	companion object {
+
+		val Center = FabPosition(0)
+
+		val End = FabPosition(1)
+	}
+
+	override fun toString(): String {
+		return when (this) {
+			Center -> "FabPosition.Center"
+			else -> "FabPosition.End"
+		}
+	}
+}

--- a/lib/src/main/java/me/onebone/toolbar/FabPosition.kt
+++ b/lib/src/main/java/me/onebone/toolbar/FabPosition.kt
@@ -1,6 +1,6 @@
 package me.onebone.toolbar
 
-enum class FabPosition(val value: Int) {
-	Center(0),
-	End(1)
+enum class FabPosition {
+	Center,
+	End
 }

--- a/lib/src/main/java/me/onebone/toolbar/FabPosition.kt
+++ b/lib/src/main/java/me/onebone/toolbar/FabPosition.kt
@@ -1,19 +1,6 @@
 package me.onebone.toolbar
 
-
-@Suppress("INLINE_CLASS_DEPRECATED", "EXPERIMENTAL_FEATURE_WARNING")
-inline class FabPosition internal constructor(@Suppress("unused") private val value: Int) {
-	companion object {
-
-		val Center = FabPosition(0)
-
-		val End = FabPosition(1)
-	}
-
-	override fun toString(): String {
-		return when (this) {
-			Center -> "FabPosition.Center"
-			else -> "FabPosition.End"
-		}
-	}
+enum class FabPosition(val value: Int) {
+	Center(0),
+	End(1)
 }

--- a/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
@@ -1,0 +1,101 @@
+package me.onebone.toolbar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ToolbarWithFabScaffold(
+	modifier: Modifier,
+	state: CollapsingToolbarScaffoldState,
+	scrollStrategy: ScrollStrategy,
+	toolbarModifier: Modifier = Modifier,
+	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
+	fab: @Composable () -> Unit,
+	fabPosition: FabPosition = FabPosition.End,
+	body: @Composable () -> Unit
+) {
+	SubcomposeLayout(
+		modifier = modifier
+	) { constraints ->
+
+		val toolbarScaffoldConstraints = constraints.copy(
+			minWidth = 0,
+			minHeight = 0,
+			maxHeight = constraints.maxHeight
+		)
+
+		val toolbarScaffoldPlaceables = subcompose(ToolbarWithFabScaffoldContent.ToolbarScaffold) {
+			CollapsingToolbarScaffold(
+				modifier = modifier,
+				state = state,
+				scrollStrategy = scrollStrategy,
+				toolbarModifier = toolbarModifier,
+				toolbar = toolbar,
+				body = body
+			)
+		}.map { it.measure(toolbarScaffoldConstraints) }
+
+		val fabConstraints = constraints.copy(
+			minWidth = 0,
+			minHeight = 0
+		)
+
+		val fabPlaceables = subcompose(
+			ToolbarWithFabScaffoldContent.Fab,
+			fab
+		).mapNotNull { measurable ->
+			measurable.measure(fabConstraints).takeIf { it.height != 0 && it.width != 0 }
+		}
+
+		val fabPlacement = if (fabPlaceables.isNotEmpty()) {
+			val fabWidth = fabPlaceables.maxOfOrNull { it.width } ?: 0
+			val fabHeight = fabPlaceables.maxOfOrNull { it.height } ?: 0
+			// FAB distance from the left of the layout, taking into account LTR / RTL
+			val fabLeftOffset = if (fabPosition == FabPosition.End) {
+				if (layoutDirection == LayoutDirection.Ltr) {
+					constraints.maxWidth - 16.dp.roundToPx() - fabWidth
+				} else {
+					16.dp.roundToPx()
+				}
+			} else {
+				(constraints.maxWidth - fabWidth) / 2
+			}
+
+			FabPlacement(
+				left = fabLeftOffset,
+				width = fabWidth,
+				height = fabHeight
+			)
+		} else {
+			null
+		}
+
+		val fabOffsetFromBottom = fabPlacement?.let {
+			it.height + 16.dp.roundToPx()
+		}
+
+		val width = constraints.maxWidth
+		val height = constraints.maxHeight
+
+		layout(width, height) {
+			toolbarScaffoldPlaceables.forEach {
+				it.place(0, 0)
+			}
+
+			fabPlacement?.let { placement ->
+				fabPlaceables.forEach {
+					it.place(placement.left, height - fabOffsetFromBottom!!)
+				}
+			}
+
+		}
+
+	}
+}
+
+private enum class ToolbarWithFabScaffoldContent {
+	ToolbarScaffold, Fab
+}

--- a/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
+@ExperimentalToolbarApi
 @Composable
 fun ToolbarWithFabScaffold(
 	modifier: Modifier,


### PR DESCRIPTION
Added Fab to scaffold layout so you don't have to wrap scaffold layout inside a box and put fab there.

How to add fab:

```
CollapsingToolbarScaffold(
    state = rememberCollapsingToolbarScaffoldState(), // provide the state of the scaffold
    toolbar = {
        // contents of toolbar go here...
    },
   floatingActionButton = {
       // contents of fab go here..
   },
   floatingActionButtonPosition = FabPosition.END, // position of fab
) {
    // main contents go here...
}
```