### PR TITLE
Point to a standard license URL in POM

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -40,7 +40,7 @@ afterEvaluate {
 					licenses {
 						license {
 							name = 'MIT License'
-							url = 'https://raw.githubusercontent.com/onebone/compose-collapsing-toolbar/master/LICENSE'
+							url = 'https://opensource.org/licenses/MIT'
 						}
 					}
 


### PR DESCRIPTION
Using a standard license URL allows companies to automate validation of third-party library licenses. Because this library points to its own repository for the license, each company would have to manually allow-list it. For instance, Square uses https://github.com/cashapp/licensee that maintains a list of common URLs used for MIT License: https://github.com/cashapp/licensee/blob/4ae8efb9b5a8ea34dcf35d200154e097347f1d9d/src/main/kotlin/app/cash/licensee/licenses.kt#L76:L79