### PR TITLE
Support placing child at fixed position regardless of scroll state

### DIFF
--- a/app/src/main/java/me/onebone/toolbar/ParallaxActivity.kt
+++ b/app/src/main/java/me/onebone/toolbar/ParallaxActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -119,6 +120,16 @@ fun ParallaxEffect() {
 							.padding(4.dp)
 					)
 				}
+			}
+
+			@OptIn(ExperimentalToolbarApi::class)
+			Button(
+				modifier = Modifier
+					.padding(16.dp)
+					.align(Alignment.BottomEnd),
+				onClick = {  }
+			) {
+				Text(text = "Floating Button!")
 			}
 		}
 

--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
@@ -31,9 +31,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.SaverScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.ParentDataModifier
+import androidx.compose.ui.unit.Density
 import kotlin.math.max
 
 @Stable
@@ -70,6 +73,11 @@ fun rememberCollapsingToolbarScaffoldState(
 	}
 }
 
+interface CollapsingToolbarScaffoldScope {
+	@ExperimentalToolbarApi
+	fun Modifier.align(alignment: Alignment): Modifier
+}
+
 @Composable
 fun CollapsingToolbarScaffold(
 	modifier: Modifier,
@@ -78,7 +86,7 @@ fun CollapsingToolbarScaffold(
 	enabled: Boolean = true,
 	toolbarModifier: Modifier = Modifier,
 	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
-	body: @Composable () -> Unit
+	body: @Composable CollapsingToolbarScaffoldScope.() -> Unit
 ) {
 	val flingBehavior = ScrollableDefaults.flingBehavior()
 
@@ -96,7 +104,7 @@ fun CollapsingToolbarScaffold(
 			) {
 				toolbar()
 			}
-			body()
+			CollapsingToolbarScaffoldScopeInstance.body()
 		},
 		modifier = modifier
 			.then(
@@ -146,3 +154,21 @@ fun CollapsingToolbarScaffold(
 		}
 	}
 }
+
+internal object CollapsingToolbarScaffoldScopeInstance: CollapsingToolbarScaffoldScope {
+	@ExperimentalToolbarApi
+	override fun Modifier.align(alignment: Alignment): Modifier =
+		this.then(ScaffoldChildAlignmentModifier(alignment))
+}
+
+private class ScaffoldChildAlignmentModifier(
+	private val alignment: Alignment
+) : ParentDataModifier {
+	override fun Density.modifyParentData(parentData: Any?): Any {
+		return (parentData as? ScaffoldParentData) ?: ScaffoldParentData(alignment)
+	}
+}
+
+data class ScaffoldParentData(
+	var alignment: Alignment? = null
+)

--- a/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
@@ -16,7 +16,7 @@ fun ToolbarWithFabScaffold(
 	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
 	fab: @Composable () -> Unit,
 	fabPosition: FabPosition = FabPosition.End,
-	body: @Composable () -> Unit
+	body: @Composable CollapsingToolbarScaffoldScope.() -> Unit
 ) {
 	SubcomposeLayout(
 		modifier = modifier


### PR DESCRIPTION
It is a common use case of collapsing toolbar to place its child at a fixed position, floating buttons, for example.

Previously, the library did not directly let users do it and should have needed to offset components manually with the `scrollY` state. With this change, it is now possible to place it with the new modifier `Modifier.align` in the `CollapsingToolbarScaffold` body. This is somewhat similar to `layout_gravity` property in the Jetpack's CollapsingToolbarLayout.

Usage example can be found at `ParallaxActivity.kt` in the *app* module.

### Backwards compatibility
`body` parameter at `CollapsingToolbarScaffold` changes its signature from `() -> Unit` to `CollapsingToolbarScaffoldScope.() -> Unit`. Although it is a non-breaking change in general, there might be some use cases where body lambda is initialized somewhere before then passing the lambda to the function which causes type incompatible error.