### PR TITLE
Fix velocity tracker is considering wrong values

### DIFF
--- a/lib/src/main/java/me/onebone/toolbar/ScrollStrategy.kt
+++ b/lib/src/main/java/me/onebone/toolbar/ScrollStrategy.kt
@@ -87,7 +87,10 @@ internal class EnterAlwaysNestedScrollConnection(
 
 	override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
 		val dy = available.y
-		tracker.delta(dy)
+
+		if (source == NestedScrollSource.Drag) {
+			tracker.delta(dy)
+		}
 
 		val toolbar = toolbarState.height.toFloat()
 		val offset = offsetY.value.toFloat()
@@ -138,7 +141,10 @@ internal class EnterAlwaysCollapsedNestedScrollConnection(
 
 	override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
 		val dy = available.y
-		tracker.delta(dy)
+
+		if (source == NestedScrollSource.Drag) {
+			tracker.delta(dy)
+		}
 
 		val consumed = if(dy > 0) { // expanding: offset -> body -> toolbar
 			val offsetConsumption = dy.coerceAtMost(-offsetY.value.toFloat())
@@ -198,7 +204,10 @@ internal class ExitUntilCollapsedNestedScrollConnection(
 
 	override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
 		val dy = available.y
-		tracker.delta(dy)
+
+		if (source == NestedScrollSource.Drag) {
+			tracker.delta(dy)
+		}
 
 		val consume = if(dy < 0) { // collapsing: toolbar -> body
 			toolbarState.dispatchRawDelta(dy)


### PR DESCRIPTION
The library makes use of its own velocity tracking logic due to #7. However, current logic for tracking velocity also considers delta values that is dispatched on flinging, which causes a wrong scroll behavior. The velocity tracker is meant to track drags only, but the `onPreScroll` also passes events on flinging with the `NestedScrollSource.Fling` `source`.

This PR addresses the issue by filtering out events whose `source` is not `NestedScrollSource.Drag`.

Not sure how, but I observe a visible performance improvement by this change. Might fix #10?