### PR TITLE
independent versioning compose compiler

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        useIR = true
     }
     buildFeatures {
         compose true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerExtensionVersion compose_compiler_version
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
     implementation 'androidx.activity:activity-compose:1.4.0'
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,9 @@ buildscript {
     ext {
         library_version = '2.3.3'
 
-        kotlin_version = '1.6.10'
+        kotlin_version = '1.7.0'
         compose_version = '1.1.1'
+        compose_compiler_version = '1.2.0'
     }
 
     repositories {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -37,7 +37,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "$compose_version"
+        kotlinCompilerExtensionVersion "$compose_compiler_version"
     }
 
     packagingOptions {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -27,7 +27,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        useIR = true
 
         freeCompilerArgs = ['-Xopt-in=kotlin.RequiresOptIn']
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -48,7 +48,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -47,7 +47,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
Now that Android Team introduce [independent versioning](https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html) that starts with the Compose Compiler version, i think we could separate the compiler version so we can update Kotlin version indepently.