### PR TITLE
API - Control hardcoded clipToBounds() modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ CollapsingToolbarScaffold(
 }
 ```
 
+By default, `CollapsingToolbar` clips content to its bounds. In order to disable it, set `toolbarClipToBounds = false` in `CollapsingToolbarScaffold`.
+
 ### CollapsingToolbarScaffoldState
 `CollapsingToolbarScaffoldState` is a holder of the scaffold state, such as the value of y offset and how much the toolbar has expanded. The field is public so you may use it as you need.
 Note that the `CollapsingToolbarScaffoldState` is stable, which means that a change on a value of the state triggers a recomposition.

--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbar.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbar.kt
@@ -199,6 +199,7 @@ fun rememberCollapsingToolbarState(
 @Composable
 fun CollapsingToolbar(
 	modifier: Modifier = Modifier,
+	clipToBounds: Boolean = true,
 	collapsingToolbarState: CollapsingToolbarState,
 	content: @Composable CollapsingToolbarScope.() -> Unit
 ) {
@@ -209,8 +210,13 @@ fun CollapsingToolbar(
 	Layout(
 		content = { CollapsingToolbarScopeInstance.content() },
 		measurePolicy = measurePolicy,
-		modifier = modifier
-			.clipToBounds()
+		modifier = modifier.then(
+			if (clipToBounds) {
+				Modifier.clipToBounds()
+			} else {
+				Modifier
+			}
+		)
 	)
 }
 

--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
@@ -86,6 +86,7 @@ fun CollapsingToolbarScaffold(
 	scrollStrategy: ScrollStrategy,
 	enabled: Boolean = true,
 	toolbarModifier: Modifier = Modifier,
+	toolbarClipToBounds: Boolean = true,
 	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
 	body: @Composable CollapsingToolbarScaffoldScope.() -> Unit
 ) {
@@ -102,7 +103,8 @@ fun CollapsingToolbarScaffold(
 		content = {
 			CollapsingToolbar(
 				modifier = toolbarModifier,
-				collapsingToolbarState = toolbarState
+				clipToBounds = toolbarClipToBounds,
+				collapsingToolbarState = toolbarState,
 			) {
 				toolbar()
 			}

--- a/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
@@ -13,6 +13,7 @@ fun ToolbarWithFabScaffold(
 	state: CollapsingToolbarScaffoldState,
 	scrollStrategy: ScrollStrategy,
 	toolbarModifier: Modifier = Modifier,
+	toolbarClipToBounds: Boolean = true,
 	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
 	fab: @Composable () -> Unit,
 	fabPosition: FabPosition = FabPosition.End,
@@ -34,6 +35,7 @@ fun ToolbarWithFabScaffold(
 				state = state,
 				scrollStrategy = scrollStrategy,
 				toolbarModifier = toolbarModifier,
+				toolbarClipToBounds = toolbarClipToBounds,
 				toolbar = toolbar,
 				body = body
 			)


### PR DESCRIPTION
First, I like this library, great job. Second, I saw that you added [this feature](https://github.com/onebone/compose-collapsing-toolbar/issues/12) to the **v3** milestone, but it's already 2 years without any progress. Please, merge it so I can use your library as a remote dependency, rather than a locally changed module.