### PR TITLE
FEATURE - Toolbar scrollable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ CollapsingToolbarScaffold(
 }
 ```
 
+By default, `CollapsingToolbar` is not scrollable. In order to enable it, set `toolbarScrollable = true` in `CollapsingToolbarScaffold`.
+
 ### CollapsingToolbarScaffoldState
 `CollapsingToolbarScaffoldState` is a holder of the scaffold state, such as the value of y offset and how much the toolbar has expanded. The field is public so you may use it as you need.
 Note that the `CollapsingToolbarScaffoldState` is stable, which means that a change on a value of the state triggers a recomposition.

--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
@@ -22,7 +22,13 @@
 
 package me.onebone.toolbar
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
@@ -35,7 +41,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.ParentDataModifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import kotlin.math.max
@@ -51,7 +59,8 @@ class CollapsingToolbarScaffoldState(
 	internal val offsetYState = mutableStateOf(initialOffsetY)
 }
 
-private class CollapsingToolbarScaffoldStateSaver: Saver<CollapsingToolbarScaffoldState, List<Any>> {
+private class CollapsingToolbarScaffoldStateSaver :
+	Saver<CollapsingToolbarScaffoldState, List<Any>> {
 	override fun restore(value: List<Any>): CollapsingToolbarScaffoldState =
 		CollapsingToolbarScaffoldState(
 			CollapsingToolbarState(value[0] as Int),
@@ -62,7 +71,7 @@ private class CollapsingToolbarScaffoldStateSaver: Saver<CollapsingToolbarScaffo
 		listOf(
 			value.toolbarState.height,
 			value.offsetY
-	)
+		)
 }
 
 @Composable
@@ -86,6 +95,7 @@ fun CollapsingToolbarScaffold(
 	scrollStrategy: ScrollStrategy,
 	enabled: Boolean = true,
 	toolbarModifier: Modifier = Modifier,
+	toolbarScrollable: Boolean = false,
 	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
 	body: @Composable CollapsingToolbarScaffoldScope.() -> Unit
 ) {
@@ -97,6 +107,7 @@ fun CollapsingToolbarScaffold(
 	}
 
 	val toolbarState = state.toolbarState
+	val toolbarScrollState = rememberScrollState()
 
 	Layout(
 		content = {
@@ -104,6 +115,13 @@ fun CollapsingToolbarScaffold(
 				modifier = toolbarModifier,
 				collapsingToolbarState = toolbarState
 			) {
+				ToolbarScrollableBox(
+					enabled,
+					toolbarScrollable,
+					toolbarState,
+					toolbarScrollState
+				)
+
 				toolbar()
 			}
 
@@ -179,7 +197,26 @@ fun CollapsingToolbarScaffold(
 	}
 }
 
-internal object CollapsingToolbarScaffoldScopeInstance: CollapsingToolbarScaffoldScope {
+@Composable
+private fun ToolbarScrollableBox(
+	enabled: Boolean,
+	toolbarScrollable: Boolean,
+	toolbarState: CollapsingToolbarState,
+	toolbarScrollState: ScrollState
+) {
+	val toolbarScrollableEnabled = enabled && toolbarScrollable
+
+	if (toolbarScrollableEnabled && toolbarState.height != Constraints.Infinity) {
+		Box(
+			modifier = Modifier
+				.fillMaxWidth()
+				.height(with(LocalDensity.current) { toolbarState.height.toDp() })
+				.verticalScroll(state = toolbarScrollState)
+		)
+	}
+}
+
+internal object CollapsingToolbarScaffoldScopeInstance : CollapsingToolbarScaffoldScope {
 	@ExperimentalToolbarApi
 	override fun Modifier.align(alignment: Alignment): Modifier =
 		this.then(ScaffoldChildAlignmentModifier(alignment))

--- a/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/ToolbarWithFabScaffold.kt
@@ -13,6 +13,7 @@ fun ToolbarWithFabScaffold(
 	state: CollapsingToolbarScaffoldState,
 	scrollStrategy: ScrollStrategy,
 	toolbarModifier: Modifier = Modifier,
+	toolbarScrollable: Boolean = false,
 	toolbar: @Composable CollapsingToolbarScope.() -> Unit,
 	fab: @Composable () -> Unit,
 	fabPosition: FabPosition = FabPosition.End,
@@ -34,6 +35,7 @@ fun ToolbarWithFabScaffold(
 				state = state,
 				scrollStrategy = scrollStrategy,
 				toolbarModifier = toolbarModifier,
+				toolbarScrollable = toolbarScrollable,
 				toolbar = toolbar,
 				body = body
 			)


### PR DESCRIPTION
By default, `CollapsingToolbar` is not scrollable. In order to enable it, set `toolbarScrollable = true` in `CollapsingToolbarScaffold`.

Preview: 

![toolbar-scrollable](https://user-images.githubusercontent.com/7150913/236879301-8b7734e1-4a2f-4f1f-bcbc-51b6942240fd.gif)
