### PR TITLE
switch compose tooling dependency to debugImplementation

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.foundation:foundation"
-    implementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-tooling"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 }
 


### PR DESCRIPTION
According to https://developer.android.com/jetpack/compose/tooling, the `androidx.compose.ui:ui-tooling` dependency should only be used in debug.