### PR TITLE
fix height issue when maxHeight changes while expanded

### DIFF
--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbar.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbar.kt
@@ -86,9 +86,10 @@ class CollapsingToolbarState(
 	var maxHeight: Int
 		get() = maxHeightState
 		internal set(value) {
+			val isExpanded = progress == 1F
 			maxHeightState = value
 
-			if(value < height) {
+			if(value < height || isExpanded) {
 				height = value
 			}
 		}


### PR DESCRIPTION
This PR aims to fix the issue mentioned in issue #100, which I'm also facing in my app.

The logic is to update `height` when `maxHeight` changes while the toolbar is fully expanded.