### PR TITLE
Fix `CollapsingToolbarScaffoldStateSaver.restore` not using the `toolbarState` parameter

### DIFF
--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbar.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbar.kt
@@ -61,7 +61,7 @@ class CollapsingToolbarState(
 	 * [height] indicates current height of the toolbar.
 	 */
 	var height: Int by mutableStateOf(initial)
-		private set
+		internal set
 
 	/**
 	 * [minHeight] indicates the minimum height of the collapsing toolbar. The toolbar

--- a/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
+++ b/lib/src/main/java/me/onebone/toolbar/CollapsingToolbarScaffold.kt
@@ -51,10 +51,14 @@ class CollapsingToolbarScaffoldState(
 	internal val offsetYState = mutableStateOf(initialOffsetY)
 }
 
-private class CollapsingToolbarScaffoldStateSaver: Saver<CollapsingToolbarScaffoldState, List<Any>> {
+private class CollapsingToolbarScaffoldStateSaver(
+	private val toolbarState: CollapsingToolbarState
+): Saver<CollapsingToolbarScaffoldState, List<Any>> {
 	override fun restore(value: List<Any>): CollapsingToolbarScaffoldState =
 		CollapsingToolbarScaffoldState(
-			CollapsingToolbarState(value[0] as Int),
+			toolbarState.apply {
+				height = value[0] as Int
+			},
 			value[1] as Int
 		)
 
@@ -69,7 +73,7 @@ private class CollapsingToolbarScaffoldStateSaver: Saver<CollapsingToolbarScaffo
 fun rememberCollapsingToolbarScaffoldState(
 	toolbarState: CollapsingToolbarState = rememberCollapsingToolbarState()
 ): CollapsingToolbarScaffoldState {
-	return rememberSaveable(toolbarState, saver = CollapsingToolbarScaffoldStateSaver()) {
+	return rememberSaveable(toolbarState, saver = CollapsingToolbarScaffoldStateSaver(toolbarState)) {
 		CollapsingToolbarScaffoldState(toolbarState)
 	}
 }


### PR DESCRIPTION
Fix #106 

`CollapsingToolbarScaffoldStateSaver.restore` not using parameter, it constructed new one by itself, causing the `toolbarState` in the `CollapsingToolbarScaffoldState` reconstructed by restore to be inconsistent with the one passed in.